### PR TITLE
Add bot support

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "dependencies": {
     "csco-spark": "3.1.0",
     "hubot": ">=2.3.0",
-    "request": "2.9.3"
+    "request": "^2.81.0",
+    "request-promise": "^4.2.1"
   },
   "devDependencies": {
     "coffee-script": "1.1.3"

--- a/src/spark-api.coffee
+++ b/src/spark-api.coffee
@@ -1,15 +1,56 @@
+requestPromise = require('request-promise')
 Spark = require('csco-spark')
 
 class SparkApi
-  constructor: (options) ->
+  person = undefined
+
+  constructor: (@sparkOptions) ->
     @spark = Spark
-      uri: options.uri
-      token: options.token
+      uri: @sparkOptions.uri
+      token: @sparkOptions.token
+
+  init: () ->
+    # Send a call to the API to see who "me" is (to verify credentials and if the person's a bot)
+    @getPeopleMe()
+
+  isBot: () ->
+    if person
+      return person.type == 'bot'
+    else
+      throw new Error('No person defined, did you initialize the connection?')
 
   getMessages: (options) ->
-    @spark.getMessages(options)
+    # Bots can only see their own messages, which csco-spark does not support
+    if @isBot()
+      @getBotMessages(options)
+    else
+      @spark.getMessages(options)
 
   sendMessage: (options) ->
-    @spark.sendMessage(arguments)
+    @spark.sendMessage(options)
+
+  getPeopleMe: () ->
+    requestOptions =
+      uri: "#{@sparkOptions.uri}/people/me"
+      headers:
+        'Authorization': "Bearer #{@sparkOptions.token}"
+
+    requestPromise(requestOptions).then((response) ->
+      person = JSON.parse(response)
+    )
+
+  getBotMessages: (options) ->
+    requestOptions =
+      uri: "#{@sparkOptions.uri}/messages"
+      headers:
+        'Authorization': "Bearer #{@sparkOptions.token}"
+      qs:
+        max: 100
+        mentionedPeople: 'me'
+        roomId: options.roomId
+
+    requestPromise(requestOptions).then((res) ->
+      JSON.parse(res).items
+    )
 
 module.exports = SparkApi

--- a/src/spark-api.coffee
+++ b/src/spark-api.coffee
@@ -1,0 +1,15 @@
+Spark = require('csco-spark')
+
+class SparkApi
+  constructor: (options) ->
+    @spark = Spark
+      uri: options.uri
+      token: options.token
+
+  getMessages: (options) ->
+    @spark.getMessages(options)
+
+  sendMessage: (options) ->
+    @spark.sendMessage(arguments)
+
+module.exports = SparkApi

--- a/src/spark.coffee
+++ b/src/spark.coffee
@@ -14,13 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ///
 
-Robot   = require('hubot').Robot
 Adapter = require('hubot').Adapter
 TextMessage = require('hubot').TextMessage
 
-HTTPS        = require 'https'
 EventEmitter = require('events').EventEmitter
-Spark       = require('csco-spark')
+SparkApi = require('./spark-api')
 
 class SparkAdapter extends Adapter
   constructor: (robot) ->
@@ -77,12 +75,13 @@ exports.use = (robot) ->
 class SparkRealtime extends EventEmitter
   self = @
   room_ids = []
+
   constructor: (options, robot) ->
     if options.access_token?
       @robot = robot
       try
         @robot.logger.info "Trying connection to #{options.api_uri}"
-        @spark = Spark
+        @spark = new SparkApi
           uri: options.api_uri
           token: options.access_token
         @robot.logger.info "Created connection instance to spark"

--- a/src/spark.coffee
+++ b/src/spark.coffee
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ///
 
+Bluebird = require('bluebird')
 Adapter = require('hubot').Adapter
 TextMessage = require('hubot').TextMessage
 
@@ -28,13 +29,13 @@ class SparkAdapter extends Adapter
     user = if envelope.user then envelope.user else envelope
     strings.forEach (str) =>
       @prepare_string str, (message) =>
-        @bot.send user,message
+        @bot.send user, message
  
   reply: (envelope, strings...) ->
     user = if envelope.user then envelope.user else envelope
     strings.forEach (str) =>
       @prepare_string str,(message) =>
-        @bot.reply user,message
+        @bot.reply user, message
  
   prepare_string: (str, callback) ->
     text = str
@@ -48,80 +49,83 @@ class SparkAdapter extends Adapter
      api_uri: process.env.HUBOT_SPARK_API_URI or "https://api.ciscospark.com/v1"
      access_token: process.env.HUBOT_SPARK_ACCESS_TOKEN
      rooms      : process.env.HUBOT_SPARK_ROOMS
+
     bot = new SparkRealtime(options, @robot)
-    @robot.logger.debug "Created bot, setting up listeners"
-    bot.listen new Date().toISOString(), (messages, room_id, last_date) =>
-      @robot.logger.debug "Fired listener callback for #{room_id}"
-      messages.forEach (message) =>
-        # checking message is received from valid group
-        if room_id in bot.room_ids
-          text = message.text
-          user_name = message.personEmail
-          user =
+    bot.init(options, @robot).then((roomIds) ->
+      self.robot.logger.debug "Created bot, setting up listeners"
+      roomIds.forEach((roomId) ->
+        bot.listen roomId, new Date().toISOString(), (messages, roomId) =>
+          self.robot.logger.debug "Fired listener callback for #{roomId}"
+          messages.forEach (message) =>
+            text = message.text
+            user =
               name: message.personEmail
               id: message.personId
               room: message.roomId
-          @robot.logger.debug "received #{text} from #{user.name}"
-          @robot.receive new TextMessage user, text
-        else
-          @robot.logger.debug "received #{text} from #{room_id} but not a room we listen to."
-    @robot.logger.debug "Done with custom bot logic"
-    @bot = bot
-    @emit 'connected'
-
-exports.use = (robot) ->
-  new SparkAdapter robot
+            self.robot.logger.debug "Received #{text} from #{user.name}"
+            self.robot.receive new TextMessage user, text
+      )
+      self.robot.logger.debug "Done with custom bot logic"
+      self.bot = bot
+      self.emit 'connected'
+    )
 
 class SparkRealtime extends EventEmitter
   self = @
-  room_ids = []
+  logger = undefined
+  spark = undefined
 
   constructor: (options, robot) ->
-    if options.access_token?
-      @robot = robot
-      try
-        @robot.logger.info "Trying connection to #{options.api_uri}"
-        @spark = new SparkApi
-          uri: options.api_uri
-          token: options.access_token
-        @robot.logger.info "Created connection instance to spark"
-      catch e
-        throw new Error "Failed to connect #{e.message}"
-      @room_ids = []
-      options.rooms.split(',').forEach (room_id) =>
-        @room_ids.push room_id
-        
-      @robot.logger.debug "Completed adding rooms to list"
-     else
-       throw new Error "Not enough parameters provided. I need an access token"
- 
+    @room_ids = []
+    if not options.access_token?
+      throw new Error "Not enough parameters provided. I need an access token"
+
+  init: (options, robot) ->
+    @robot = robot
+    logger = @robot.logger
+    logger.info "Trying connection to #{options.api_uri}"
+    spark = new SparkApi
+      uri: options.api_uri
+      token: options.access_token
+    return spark.init().then(() ->
+      logger.debug "Connected as a bot? #{spark.isBot()}"
+      logger.info "Created connection instance to Spark"
+      roomIds = []
+      options.rooms.split(',').forEach (roomId) =>
+        roomIds.push roomId
+      logger.debug "Completed adding rooms to list"
+      Bluebird.resolve(roomIds)
+    ).catch((err) ->
+      throw new Error "Failed to connect to Spark: #{err}"
+    )
+
   ## Spark API call methods
-  listen: (date, callback) ->
-    # Create a callback hook for each room
-    @room_ids.forEach (room_id) =>
-      @spark.getMessages(roomId: room_id).then (msges) =>
-        msges.forEach((msg) =>
-          if Date.parse(msg.created) > Date.parse(date)
-            @robot.logger.debug "Matched new message #{msg.text}"
-            callback [msg], room_id
-        )
-        newDate = new Date().toISOString()
-        setTimeout (=>
-          @listen newDate, callback
-        ), 10000
+  listen: (roomId, date, callback) ->
+    spark.getMessages(roomId: roomId).then (msges) =>
+      msges.forEach((msg) =>
+        if Date.parse(msg.created) > Date.parse(date)
+          @robot.logger.debug "Matched new message #{msg.text}"
+          callback [msg], roomId
+      )
+      newDate = new Date().toISOString()
+      setTimeout (=>
+        @listen roomId, newDate, callback
+      ), 10000
  
-  send: (user, message, room) ->
-    @robot.logger.debug "Sending message"
-    @room_ids.forEach (room_id) =>
-      @robot.logger.debug "send message to room #{room_id} with text #{message}"
-      @spark.sendMessage
-        roomId: room_id
-        text: message
+  send: (user, message) ->
+    @robot.logger.debug "Send message to room #{user.room} with text #{message}"
+    spark.sendMessage
+      roomId: user.room
+      text: message
  
   reply: (user, message) ->
     @robot.logger.debug "Replying to message for #{user}"
     if user
       @robot.logger.debug "reply message to #{user} with text #{message}"
-      @spark.sendMessage
+      spark.sendMessage
         text: message
         toPersonEmail: user
+
+exports.use = (robot) ->
+  new SparkAdapter robot
+


### PR DESCRIPTION
Hi!

I see you noticed my commit. I have a couple of things I'd like to verify with you before I formally send a PR (this one is a work-in-progress).

### Cisco Spark Library Change

If possible, I would like to change the underlying Spark library to the [official Cisco Spark one](https://github.com/ciscospark/spark-js-sdk). To do that, I was planning on introducing a "SparkApi" class to abstract away the implementation (`csco-spark` vs `ciscospark`). Once the class was there, as a separate commit, I'd swap out the underlying implementation. The problem with switching to the official Cisco Spark API is that they don't have an API for `/people/me` (at least none that I could find in [their documentation](https://ciscospark.github.io/spark-js-sdk/api/#CiscoSpark)), which is critical for bot support. I'd have to implement that request myself (as I've currently done in this PR).

The other thing I don't like about doing this is that we'd be losing support for the `HUBOT_SPARK_API_URI` environment variable (which I've personally found handy).

### csco-spark issues

If we stick with csco-spark, I'd have to send a PR to add support for customizing the `getMessages` API call to support `mentionedPeople` (since the API restricts bot access so they can only get messages where they are mentioned), and `/people/me`. I'd like to (ideally) avoid doing the requests in *this* library so that there's more consistent/better support for things like proxies.

What do you think? :)